### PR TITLE
Check for slurm earlier in the process

### DIFF
--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -161,6 +161,11 @@ class DRMAACluster(object):
                 raise ValueError("Invalid job template attribute %s" % key)
             setattr(jt, key, value)
 
+        session = get_session()
+        if "SLURM" in session.drmsInfo:
+            jt.outputPath = jt.outputPath.replace("$JOB_ID", "%j")
+            jt.errorPath = jt.errorPath.replace("$JOB_ID", "%j")
+
         return jt
 
     def start_workers(self, n=1, **kwargs):


### PR DESCRIPTION
This relates to https://github.com/dask/dask-drmaa/pull/33 I just moved the changes to the create job templates method

However slurm-drmaa segfaults on me and I can't actually use it.